### PR TITLE
Test updated cargo_toml behavior

### DIFF
--- a/tests/test-crates/trivial/Cargo.toml
+++ b/tests/test-crates/trivial/Cargo.toml
@@ -5,3 +5,5 @@ authors = ["Jon Gjengset <jongje@thesquareplanet.com>"]
 edition = "2018"
 
 [dependencies]
+
+[lib]


### PR DESCRIPTION
cargo_toml 0.9.0 fixes an issue where the crate-type field wasn't
roundtripped correctly if the [lib] section was present in Cargo.toml,
meaning repackaged crates would no longer build. This change bumps
the dependency and adds a [lib] section to the trivial test crate,
which causes that test to fail without the fix.
