### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ categories = ["development-tools::build-utils", "command-line-utilities"]
 [dependencies]
 anyhow = "1"
 tar = { version = "0.4.32", default-features = false }
-cargo_toml = "0.9.0"
-toml = "0.5.6"
+cargo_toml = "0.15"
+toml = "0.7"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,9 @@ pub fn dot_crate(
             // See https://github.com/alexcrichton/toml-rs/issues/142#issuecomment-278970591
             let manifest =
                 toml::Value::try_from(&manifest).context("serialize modified Cargo.toml")?;
-            let bytes = toml::to_vec(&manifest).context("serialize modified Cargo.toml")?;
+            let bytes = toml::to_string(&manifest)
+                .context("serialize modified Cargo.toml")?
+                .into_bytes();
             let mut bytes = &bytes[..]; // to give us io::Read
             header.set_size(bytes.len() as u64);
             header.set_cksum();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub fn dot_crate(
     let repackaged_path = dot_crate.with_file_name(repackaged_fn);
     let repackaged = std::fs::File::create(&repackaged_path)?;
     let dot_crate_path = dot_crate;
-    let dot_crate = std::fs::File::open(&dot_crate_path)?;
+    let dot_crate = std::fs::File::open(dot_crate_path)?;
 
     // https://github.com/rust-lang/cargo/blob/8e075c9cab41eb1ed6222f819924999476477f2e/src/cargo/ops/cargo_package.rs#L481
     let dot_crate = flate2::read::GzDecoder::new(dot_crate);
@@ -174,7 +174,7 @@ pub fn dot_crate(
             let p = manifest.package.as_mut().ok_or_else(|| {
                 anyhow::anyhow!("Cargo.toml in .crate file does not contain a package")
             })?;
-            if &p.name != old_name {
+            if p.name != old_name {
                 anyhow::bail!(
                     "crate name in .crate ('{}') file did not match given name ('{}')",
                     p.name,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! the `.crate`. But, _just_ in case, this crate tries to modify those files as well using some
 //! simple string replacement. It's brittle though, so you might only get so far with that approach
 //! if you make heavy use of non-library artifacts in the produced `.crate` files.
-#![warn(missing_docs, broken_intra_doc_links)]
+#![warn(missing_docs, rustdoc::broken_intra_doc_links)]
 
 use anyhow::Context;
 use cargo_toml::Manifest;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,5 +7,5 @@ fn main() -> anyhow::Result<()> {
         );
     }
 
-    repackage::dot_crate(&args.next().unwrap(), None, &args.next().unwrap())
+    repackage::dot_crate(args.next().unwrap(), None, &args.next().unwrap())
 }


### PR DESCRIPTION
Updates `repackage`'s dependencies so that it no longer relies on a yanked
version of `cargo_toml`. I also did some drive-by fixes that `clippy` suggested.
